### PR TITLE
refresh bug on mobile bug fix

### DIFF
--- a/frontend/src/components/SiteHeader.vue
+++ b/frontend/src/components/SiteHeader.vue
@@ -48,7 +48,11 @@ function getInfo() {
       return;
     }
 function reload(){
+
   const time = Date.parse(localStorage.getItem('time'));
+  if(time){
+    return false;
+  }
   const currentTime = new Date(Date.now());
   const timeLeft = time - currentTime;
   console.log("time",time)


### PR DESCRIPTION
when token was null or negative value the site went into a refresh loop. And for some reason going into mobile mode triggered it to bug out even more. this was fixed by doing returning false, if token was null or negative